### PR TITLE
Access to pyppeteer.page.Page objects

### DIFF
--- a/scrapy_pyppeteer/download_handler.py
+++ b/scrapy_pyppeteer/download_handler.py
@@ -42,13 +42,17 @@ class ScrapyPyppeteerDownloadHandler(HTTPDownloadHandler):
             self.navigation_timeout = settings.getint("PYPPETEER_NAVIGATION_TIMEOUT")
 
     def download_request(self, request: Request, spider: Spider) -> Deferred:
-        if request.meta.get("pyppeteer_enable"):
+        if request.meta.get("pyppeteer"):
             return _force_deferred(self._download_request(request, spider))
         return super().download_request(request, spider)
 
     async def _download_request(self, request: Request, spider: Spider) -> Response:
         if self.browser is None:
             self.browser = await pyppeteer.launch(options=self.launch_options)
+
+        meta = {}
+        if isinstance(request.meta.get("pyppeteer"), dict):
+            meta = request.meta["pyppeteer"]
 
         page = await self.browser.newPage()
         if self.navigation_timeout is not None:
@@ -57,7 +61,7 @@ class ScrapyPyppeteerDownloadHandler(HTTPDownloadHandler):
         page.on("request", partial(_set_request_headers, scrapy_request=request))
         response = await page.goto(request.url)
 
-        page_coroutines = request.meta.get("pyppeteer_page_coroutines") or []
+        page_coroutines = meta.get("page_coroutines") or ()
         for pc in page_coroutines:
             if isinstance(pc, PageCoroutine):
                 method = getattr(page, pc.method)
@@ -72,7 +76,10 @@ class ScrapyPyppeteerDownloadHandler(HTTPDownloadHandler):
                 response = result
 
         body = (await page.content()).encode("utf8")
-        await page.close()
+        if meta.get("include_page"):
+            meta["page"] = page
+        else:
+            await page.close()
         response.headers.pop("content-encoding", None)
         respcls = responsetypes.from_args(headers=response.headers, url=response.url, body=body)
         return respcls(

--- a/tests/test_mixed_requests.py
+++ b/tests/test_mixed_requests.py
@@ -39,5 +39,5 @@ class MixedRequestsTestCase(TestCase):
             self.assertEqual(response.status, 200)
             self.assertIn("pyppeteer", response.flags)
 
-        request = Request(self.base_url + "/index.html", meta={"pyppeteer_enable": True})
+        request = Request(self.base_url + "/index.html", meta={"pyppeteer": True})
         return self.handler.download_request(request, Spider("foo")).addCallback(_test)

--- a/tests/test_pyppeteer_requests.py
+++ b/tests/test_pyppeteer_requests.py
@@ -18,7 +18,7 @@ async def test_basic_response():
     handler = ScrapyPyppeteerDownloadHandler(Settings())
 
     with MockServer() as server:
-        req = Request(server.urljoin("/index.html"))
+        req = Request(server.urljoin("/index.html"), meta={"pyppeteer": True})
         resp = await handler._download_request(req, Spider("foo"))
 
     assert isinstance(resp, Response)
@@ -39,7 +39,9 @@ async def test_page_coroutine_navigation():
         req = Request(
             url=server.urljoin("/index.html"),
             meta={
-                "pyppeteer_page_coroutines": [NavigationPageCoroutine("click", "a.lorem_ipsum")]
+                "pyppeteer": {
+                    "page_coroutines": [NavigationPageCoroutine("click", "a.lorem_ipsum")]
+                }
             },
         )
         resp = await handler._download_request(req, Spider("foo"))
@@ -64,13 +66,15 @@ async def test_page_coroutine_infinite_scroll():
         req = Request(
             url=server.urljoin("/scroll.html"),
             meta={
-                "pyppeteer_page_coroutines": [
-                    PageCoroutine("waitForSelector", "div.quote"),  # first 10 quotes
-                    PageCoroutine("evaluate", "window.scrollBy(0, 2000)"),
-                    PageCoroutine("waitForSelector", "div.quote:nth-child(11)"),  # second request
-                    PageCoroutine("evaluate", "window.scrollBy(0, 2000)"),
-                    PageCoroutine("waitForSelector", "div.quote:nth-child(21)"),  # third request
-                ],
+                "pyppeteer": {
+                    "page_coroutines": [
+                        PageCoroutine("waitForSelector", "div.quote"),  # first 10 quotes
+                        PageCoroutine("evaluate", "window.scrollBy(0, 2000)"),
+                        PageCoroutine("waitForSelector", "div.quote:nth-child(11)"),  # 2nd request
+                        PageCoroutine("evaluate", "window.scrollBy(0, 2000)"),
+                        PageCoroutine("waitForSelector", "div.quote:nth-child(21)"),  # 3rd request
+                    ],
+                }
             },
         )
         resp = await handler._download_request(req, Spider("foo"))
@@ -102,10 +106,14 @@ async def test_page_coroutine_screenshot_pdf():
         req = Request(
             url=server.urljoin("/index.html"),
             meta={
-                "pyppeteer_page_coroutines": [
-                    PageCoroutine("screenshot", options={"path": image_file.name, "type": "png"}),
-                    PageCoroutine("pdf", options={"path": pdf_file.name}),
-                ],
+                "pyppeteer": {
+                    "page_coroutines": [
+                        PageCoroutine(
+                            "screenshot", options={"path": image_file.name, "type": "png"}
+                        ),
+                        PageCoroutine("pdf", options={"path": pdf_file.name}),
+                    ]
+                },
             },
         )
         await handler._download_request(req, Spider("foo"))
@@ -125,7 +133,9 @@ async def test_page_coroutine_timeout():
     with MockServer() as server:
         req = Request(
             url=server.urljoin("/index.html"),
-            meta={"pyppeteer_page_coroutines": [NavigationPageCoroutine("click", selector="h1")]},
+            meta={
+                "pyppeteer": {"page_coroutines": [NavigationPageCoroutine("click", selector="h1")]}
+            },
         )
         with pytest.raises(pyppeteer.errors.TimeoutError):
             await handler._download_request(req, Spider("foo"))


### PR DESCRIPTION
Closes #1

Also changed the name of the request meta key: `pyppeteer_enable` -> `pyppeteer`

To do:
* [x] Implementation
* [x] Tests
* [x] Docs (mention the need for `await Page.close()`)